### PR TITLE
Latex error: Shaded environment not defined

### DIFF
--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -136,9 +136,7 @@ $endif$
 $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
 $endif$
-$if(highlighting-macros)$
-$highlighting-macros$
-$endif$
+
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 \VerbatimFootnotes % allows verbatim text in footnotes

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -26,11 +26,6 @@ $endif$
 \hypersetup{colorlinks=true, linkcolor = blue, urlcolor = blue}
 \usepackage{eso-pic}
 
-% fix shaded environment issue when no code chunks included.
-$if(highlighting-macros)$
-$highlighting-macros$
-$endif$
-
 \renewcommand{\baselinestretch}{1.5}  % line distance is 1.5
 
 %\renewcommand{\chaptername}{} %% remove the word \chapter
@@ -136,7 +131,9 @@ $endif$
 $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
 $endif$
-
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 \VerbatimFootnotes % allows verbatim text in footnotes
@@ -240,8 +237,10 @@ $endif$
  \at@end@of@kframe}
 \makeatother
 
-\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}
-
+\makeatletter
+\@ifundefined{Shaded}{
+}{\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}}
+\makeatother
 
 
 

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -18,6 +18,8 @@ $endif$
 \usepackage{ifxetex,ifluatex}
 \usepackage[nottoc]{tocbibind}
 
+
+
 % some more packages...
 \usepackage{graphicx}
 \usepackage{scrpage2}
@@ -25,6 +27,7 @@ $endif$
 \usepackage{hyperref}
 \hypersetup{colorlinks=true, linkcolor = blue, urlcolor = blue}
 \usepackage{eso-pic}
+
 
 \renewcommand{\baselinestretch}{1.5}  % line distance is 1.5
 

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -18,8 +18,6 @@ $endif$
 \usepackage{ifxetex,ifluatex}
 \usepackage[nottoc]{tocbibind}
 
-
-
 % some more packages...
 \usepackage{graphicx}
 \usepackage{scrpage2}
@@ -28,6 +26,10 @@ $endif$
 \hypersetup{colorlinks=true, linkcolor = blue, urlcolor = blue}
 \usepackage{eso-pic}
 
+% fix shaded environment issue when no code chunks included.
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
 
 \renewcommand{\baselinestretch}{1.5}  % line distance is 1.5
 


### PR DESCRIPTION
As per: https://github.com/yihui/bookdown-chinese/commit/a3e392593b464ba31a7eceb0cd60f7e0bd112798 

I get an issue knitting when there are no code chunks included. This fixes it for me.

`\renewenvironment{Shaded}` doesn't work if it isn't already defined. 