### PR TITLE
Change scrpage2 to scrlayer-scrpage

### DIFF
--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -22,7 +22,7 @@ $endif$
 
 % some more packages...
 \usepackage{graphicx}
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 \usepackage{xcolor}
 \usepackage{hyperref}
 \hypersetup{colorlinks=true, linkcolor = blue, urlcolor = blue}


### PR DESCRIPTION
Trying to address #17 since scrpage2 seems to be deprecated. Suggestion on [StackExchange](https://tex.stackexchange.com/questions/541766/latex-error-file-scrpage2-sty-not-found) is to use scrlayer-scrpage, which should recognize all scrpage2 commands.